### PR TITLE
Added support for URL management via file.

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -247,7 +247,7 @@ FeedApplet.prototype = {
                 null);
 
         this.settings.bindProperty(Settings.BindingDirection.IN,
-                "feed_source", "feed_source", this.feed_source_changed, null);
+                "use_list_file", "use_list_file", this.feed_source_changed, null);
 
         this.settings.bindProperty(Settings.BindingDirection.IN,
                 "url", "url", this.url_changed, null);
@@ -314,7 +314,7 @@ FeedApplet.prototype = {
 
     feed_list_file_changed: function() {
         // if the file is not the source don't do anything
-        if (this.feed_source != 1) return;
+        if (! this.use_list_file) return;
         let filename = this.list_file;
         let url_list = [];
         try {
@@ -340,8 +340,7 @@ FeedApplet.prototype = {
 
     url_changed: function() {
         // if the list is not the source, don't do anything
-        global.logError("source: " + this.feed_source);
-        if (this.feed_source != 0) return;
+        if (this.use_list_file) return;
         let url_list = this.url.replace(/\s+/g, " ").replace(/\s*$/, '').replace(/^\s*/, '').split(" ");
         for (var i in url_list) {
             global.logError("url: '" + url_list[i] + "'");

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -5,21 +5,18 @@
         "description" : "Feed URL(s)",
         "tooltip" : "Enter the URLs of a valid RSS/Atom feed. Separate multiple URLs with spaces"
     },
+    "use_list_file" : {
+        "type" : "checkbox",
+        "default" : false,
+        "description" : "Use file as source of feeds instead of above list"
+    },
     "list_file": {
         "type" : "filechooser",
         "default" : "",
         "description" : "Feed List File",
-        "tooltip" : "Path to a text file with one feed URL per line"
-    },
-    "feed_source" : {
-        "type" : "radiogroup",
-        "default" : 0,
-        "description" : "Feed Source",
-        "tooltip" : "Select the source of feeds you want to use",
-        "options" : {
-            "URL list" : 0,
-            "URL file" : 1
-        }
+        "tooltip" : "Path to a text file with one feed URL per line",
+        "indent" : true,
+        "dependency" : "use_list_file"
     },
     "max_items": {
             "type" : "scale",


### PR DESCRIPTION
```
I added a second method to manage the feeds using a file.
There is a new settings field specifing a path to a file. The user can then
add one feed url per line.
A second new settings field is used to switch between the two methods.
I also added a new context menu entry which reloads the file.
```
