### PR TITLE
New feed_file features: Custom title, comments and edit from context menu

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -513,7 +513,7 @@ FeedApplet.prototype = {
     },
 
     edit_feeds_file: function() {
-        GLib.spawn_command_line_async('gedit "' + this.list_file + '"');
+        GLib.spawn_command_line_async('xdg-open "' + this.list_file + '"');
     },
 
     url_changed: function() {


### PR DESCRIPTION
Hey, I've got some new features for the feed file, to make it more convenient to use.
(I have a feed with a ridiculously long title, which gave me the idea to the custom titles :-) )

```
* Added "edit feed file" context menu entry which launces gedit with the feed file
* Added comment support for feed file: lines starting with '#' will be ignored
* Added custom title support: The user can specify a custom title for each feed to be displayed instead of the RSS title:
    <feed_url> <custom_title>
```
