### PR TITLE
Remove some xsession errors

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -222,7 +222,7 @@ FeedDisplayMenuItem.prototype = {
 
         this.menu.connect('open-state-changed', Lang.bind(this, this.on_open_state_changed));
 
-        this.update();
+        Mainloop.idle_add(Lang.bind(this, this.update));
     },
 
     update_params: function(params) {


### PR DESCRIPTION
The function update causes a bunch of errors if the stage isn't one of its ancestors (which is always the case when Cinnamon is first started - this gets a bit annoying when you restart cinnamon a lot like me). This fix waits to make sure all necessary actors have been added before running the update function.
