### PR TITLE
Remove reference to non-existant function

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -427,7 +427,6 @@ FeedApplet.prototype = {
                 Lang.bind(this, function() {
                     for (var i = 0; i < this.feeds.length; i++)
                         this.feeds[i].mark_all_items_read();
-                    this.build_menu();
                 }));
         s.icon.icon_type = St.IconType.SYMBOLIC;
         this._applet_context_menu.addMenuItem(s);


### PR DESCRIPTION
The function build_menu was removed in https://github.com/jonbrett/cinnamon-feeds-applet/commit/91d4a52e646689ac5aba9ca94ce92cc5796eddd8. This removes the last reference to it (causes an error in .xsession-errors when the context "Mark all read" is clicked).
