### PR TITLE
Bug fix: applet won't start due to a callback error.

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -419,16 +419,12 @@ FeedApplet.prototype = {
                 "show_feed_image", "show_feed_image", this.update_params, null);
 
         this.settings.bindProperty(Settings.BindingDirection.IN,
-                "notifications_enabled", "notifications_enabled", this.empty_function, null);
+                "notifications_enabled", "notifications_enabled", this.update_params, null);
 
         this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
                 "url", "url_list_str", this.url_changed, null);
 
         this.url_changed();
-    },
-
-    empty_function: function() {
-
     },
 
     build_context_menu: function() {


### PR DESCRIPTION
The applet would not show on my taskbar until I removed the null callback value from bindProperty. I'm running Mint 15 with Cinnamon 1.8

My solution isn't elegant, since we now have a useless function cluttering the code. If you want me to replace this with a different function call, let me know. As long as the value is a valid function and not null, the problem is fixed.
