### PR TITLE
Update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ The latest stable release can be installed from
 * The Cinnamon spices Website [http://cinnamon-spices.linuxmint.com/applets/view/149]
 * Directly from the Cinnamon applets settings (right-click the Cinnamon panel and got to "add applets"
 
-Alternatively you can clone this repository directly into the following location
+Alternatively you can clone this repository and compile it yourself.
 ```
-cd ~/.local/share/cinnamon/applets
 git clone https://github.com/jonbrett/cinnamon-feeds-applet.git feeds@jonbrettdev.wordpress.com
+cd feeds@jonbrettdev.wordpress.com
+make
+cp -r ./BUILD/feeds@jonbrettdev.wordpress.com ~/.local/share/cinnamon/applets
 ```
+
+If you intend on modifying the codebase, remember to commit your changes before compiling. The BUILD directory will only contain code committed to Git.


### PR DESCRIPTION
The current instructions may confuse a new user. The README says to directly clone the repo into the applets folder, however this doesn't allow out of the box support. The user may not understand that they were supposed to "make" first.

The Add Applets program also displays Feeds  as an option to install before it's even compiled. When the user chooses to install the applet like that, the program won't actually work, but will be listed as installed. Even if the user then proceeds to "make" after this, Cinnamon will not traverse deeper into the BUILD folder to find the correct software. The user is now stuck until they move the contents of BUILD up to the applets folder, while deleting the Git repo to stop confusing Cinnamon. 

The new instructions will help someone who may be confused. Also, it may not be obvious that compiling will only take the changes committed to Git, so I have added some info about it to prevent a user wondering why their uncommitted changes aren't compiling.
