### PR TITLE
Fixed issue where "Mark all read" didn't work

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -162,8 +162,10 @@ FeedApplet.prototype = {
                 _("Mark all read"),
                 "object-select-symbolic",
                 Lang.bind(this, function() {
-                    for (var i = 0; i < this.feeds.length; i++)
-                        this.feeds[i].mark_all_items_read();
+                    for (var i = 0; i < this.feeds.length; i++) {
+                        this.feeds[i].reader.mark_all_items_read();
+                        this.feeds[i].update();
+                    }
                 }));
         this._applet_context_menu.addMenuItem(s);
 


### PR DESCRIPTION
"Mark all read" menu item was calling the wrong function on the wrong object.